### PR TITLE
Adding in a noticeboard

### DIFF
--- a/.github/workflows/pr_gate.yaml
+++ b/.github/workflows/pr_gate.yaml
@@ -26,7 +26,7 @@ jobs:
   linux:
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-latest
 
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
-          architecture: x64
 
       - name: Install the package
         run: pip install -e .[test]
@@ -65,7 +64,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
-          architecture: x64
 
       - name: Install the package
         run: pip install -e .[test]
@@ -92,7 +90,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
-          architecture: x64
 
       - name: Install the package
         run: pip install -e .[test]

--- a/.github/workflows/pr_gate.yaml
+++ b/.github/workflows/pr_gate.yaml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Use Python 3.8
-        uses: actions/setup-python@v4
+      - name: Use Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install the package
         run: pip install -e .[linting]
@@ -26,16 +26,16 @@ jobs:
   linux:
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
           architecture: x64
@@ -44,7 +44,7 @@ jobs:
         run: pip install -e .[test]
 
       - name: Run tests
-        uses: pavelzw/pytest-action@v1
+        uses: pavelzw/pytest-action@v2
         with:
           verbose: true
           job_summary: true
@@ -53,16 +53,16 @@ jobs:
   windows:
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     runs-on: windows-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
           architecture: x64
@@ -71,7 +71,7 @@ jobs:
         run: pip install -e .[test]
 
       - name: Run tests
-        uses: pavelzw/pytest-action@v1
+        uses: pavelzw/pytest-action@v2
         with:
           verbose: true
           job_summary: true
@@ -80,16 +80,16 @@ jobs:
   macos:
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.10", "3.11", "3.12"]
 
     runs-on: macos-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
           architecture: x64

--- a/src/pyrona/__init__.py
+++ b/src/pyrona/__init__.py
@@ -1,7 +1,7 @@
 """Pyrona is a Python package that simulates a BoC runtime for Python."""
 
 from .core import (is_imm, Region, region, RegionIsolationError, regions)
-from .notice import (notice_compare_exchange, notice_exchange, notice_read, notice_register)
+from .notice import (notice_changed, notice_clear, notice_read, notice_write)
 from .version import __version__
 from .when import (wait, when)
 
@@ -16,8 +16,8 @@ __all__ = [
     "when",
     "is_imm",
     "__version__",
-    "notice_compare_exchange",
-    "notice_exchange",
+    "notice_changed",
+    "notice_clear",
     "notice_read",
-    "notice_register",
+    "notice_write",
 ]

--- a/src/pyrona/__init__.py
+++ b/src/pyrona/__init__.py
@@ -1,6 +1,7 @@
 """Pyrona is a Python package that simulates a BoC runtime for Python."""
 
 from .core import (is_imm, Region, region, RegionIsolationError, regions)
+from .notice import (notice_compare_exchange, notice_exchange, notice_read, notice_register)
 from .version import __version__
 from .when import (wait, when)
 
@@ -14,5 +15,9 @@ __all__ = [
     "wait",
     "when",
     "is_imm",
-    "__version__"
+    "__version__",
+    "notice_compare_exchange",
+    "notice_exchange",
+    "notice_read",
+    "notice_register",
 ]

--- a/src/pyrona/notice.py
+++ b/src/pyrona/notice.py
@@ -108,7 +108,7 @@ class NoticeBoard:
         if key not in self.notices:
             raise KeyError(f"Notice '{key}' not found.")
 
-        self.notices[key].exchange(value)
+        return self.notices[key].exchange(value)
 
     def compare_exchange(self, key: str, value: Any, comparand: Any) -> Any:
         """Compare and exchange the value of a notice.

--- a/src/pyrona/notice.py
+++ b/src/pyrona/notice.py
@@ -1,0 +1,169 @@
+"""Implementation of a concurrent-safe notice system."""
+
+from threading import Event, Lock
+from typing import Any, List, Mapping
+
+from .core import is_imm
+
+
+class Notice:
+    """A notice is a many-reader, one-writer concurrency primitive.
+
+    In this demonstrator, the notice is a simple wrapper around a threading.Event.
+    However, with the use of atomics it can be made lock-free.
+    """
+
+    def __init__(self):
+        """Initialize the notice."""
+        self.lock = Lock()
+        self.event = Event()
+        self.event.set()
+        self.value = None
+
+    def read(self) -> Any:
+        """Read the value of the notice.
+
+        This will only block if the notice is actively being written to.
+        """
+        self.event.wait()
+        return self.value
+
+    def exchange(self, value: Any) -> Any:
+        """Write a value to the notice.
+
+        This will block any readers until the value is read.
+
+        Args:
+            value: The value to write to the notice. Must be immutable.
+        """
+        if not is_imm(value):
+            raise ValueError("Value must be immutable.")
+
+        with self.lock:
+            prev = self.value
+            self.event.clear()
+            self.value = value
+            self.event.set()
+            return prev
+
+    def compare_exchange(self, value: Any, comparand: Any) -> Any:
+        """Compare and exchange the value of the notice.
+
+        This will only block if the notice is actively being written to.
+        The exchange will only occur if the value is equal to the comparand.
+
+        Args:
+            value: The new value to write to the notice. Must be immutable.
+            comparand: The value to compare against.
+
+        Returns:
+            The previous value of the notice.
+        """
+        if not is_imm(value):
+            raise ValueError("Value must be immutable.")
+
+        with self.lock:
+            if self.value == comparand:
+                prev = self.value
+                self.event.clear()
+                self.value = value
+                self.event.set()
+                return prev
+
+            return self.value
+
+
+class NoticeBoard:
+    """A notice board is a collection of notices."""
+
+    def __init__(self, names: List[str]):
+        """Initialize the notice board.
+
+        Args:
+            names: A list of names for the notices.
+        """
+        self.notices: Mapping[str, Notice] = {name: Notice() for name in names}
+
+    def read(self, key: str) -> Any:
+        """Read the value of a notice.
+
+        Args:
+            key: The name of the notice to read.
+
+        Returns:
+            The value of the notice.
+        """
+        if key not in self.notices:
+            raise KeyError(f"Notice '{key}' not found.")
+
+        return self.notices[key].read()
+
+    def exchange(self, key: str, value: Any):
+        """Write a value to a notice.
+
+        Args:
+            key: The name of the notice to write to.
+            value: The value to write to the notice. Must be immutable.
+        """
+        if key not in self.notices:
+            raise KeyError(f"Notice '{key}' not found.")
+
+        self.notices[key].exchange(value)
+
+    def compare_exchange(self, key: str, value: Any, comparand: Any) -> Any:
+        """Compare and exchange the value of a notice.
+
+        Args:
+            key: The name of the notice to write to.
+            value: The new value to write to the notice. Must be immutable.
+            comparand: The value to compare against.
+
+        Returns:
+            The previous value of the notice.
+        """
+        if key not in self.notices:
+            raise KeyError(f"Notice '{key}' not found.")
+
+        return self.notices[key].compare_exchange(value, comparand)
+
+
+noticeboard = None
+
+
+def notice_register(names: List[str]):
+    """Register a list of notice names.
+
+    Args:
+        names: A list of names for the notices.
+    """
+    global noticeboard
+    noticeboard = NoticeBoard(names)
+
+
+def notice_read(key: str) -> Any:
+    """Read the value of a notice."""
+    return noticeboard.read(key)
+
+
+def notice_exchange(key: str, value: Any) -> Any:
+    """Write a value to a notice.
+
+    Args:
+        key: The name of the notice to write to.
+        value: The value to write to the notice. Must be immutable.
+    """
+    return noticeboard.exchange(key, value)
+
+
+def notice_compare_exchange(key: str, value: Any, comparand: Any) -> Any:
+    """Compare and exchange the value of a notice.
+
+    Args:
+        key: The name of the notice to write to.
+        value: The new value to write to the notice. Must be immutable.
+        comparand: The value to compare against.
+
+    Returns:
+        The previous value of the notice.
+    """
+    return noticeboard.notices[key].compare_exchange(value, comparand)

--- a/tests/test_notices.py
+++ b/tests/test_notices.py
@@ -1,0 +1,48 @@
+"""Tests for the noticeboard."""
+
+from pyrona import (
+    notice_compare_exchange,
+    notice_exchange,
+    notice_read,
+    notice_register,
+    wait,
+    when
+)
+
+
+def test_io():
+    notice_register(["foo", "bar"])
+    notice_exchange("foo", 42)
+    assert notice_read("foo") == 42
+    notice_exchange("bar", "baz")
+    assert notice_read("bar") == "baz"
+
+
+def test_counting():
+    notice_register(["count"])
+    notice_exchange("count", 0)
+
+    for _ in range(10):
+        @when()
+        def _():
+            value = notice_read("count")
+            while True:
+                if value == notice_compare_exchange("count", value + 1, value):
+                    break
+
+    @when()
+    def _():
+        assert notice_read("count") == 10
+
+    wait()
+
+
+def test_not_immutable():
+    notice_register(["foo"])
+
+    try:
+        notice_exchange("foo", [])
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError.")

--- a/tests/test_notices.py
+++ b/tests/test_notices.py
@@ -37,6 +37,31 @@ def test_counting():
     wait()
 
 
+def test_ordering():
+    notice_register(["foo", "bar"])
+    notice_exchange("foo", 42)
+    notice_exchange("bar", 24)
+
+    for _ in range(10):
+        @when()
+        def _():
+            assert notice_read("foo") == 42
+            assert notice_read("bar") == 24
+
+    @when()
+    def _():
+        notice_exchange("foo", 24)
+        notice_exchange("bar", 42)
+
+    for _ in range(10):
+        @when()
+        def _():
+            assert notice_read("foo") == 24
+            assert notice_read("bar") == 42
+
+    wait()
+
+
 def test_not_immutable():
     notice_register(["foo"])
 
@@ -46,3 +71,28 @@ def test_not_immutable():
         pass
     else:
         raise AssertionError("Expected ValueError.")
+
+
+def test_exists():
+    notice_register(["foo"])
+
+    try:
+        notice_read("bar")
+    except KeyError:
+        pass
+    else:
+        raise AssertionError("Expected KeyError.")
+
+    try:
+        notice_exchange("bar", 42)
+    except KeyError:
+        pass
+    else:
+        raise AssertionError("Expected KeyError.")
+
+    try:
+        notice_compare_exchange("bar", 42, 0)
+    except KeyError:
+        pass
+    else:
+        raise AssertionError("Expected KeyError.")


### PR DESCRIPTION
Adding a noticeboard via the following four methods:

1. `notice_clear()` - this acquires the `notice` cown and then clears the noticeboard
2. `notice_read(key)` - this checks to see if the current thread has read the noticeboard before. if so, it uses that cached copy. Otherwise, it copies the current value (this is a global) as a cached value and stores it on the thread. It then returns the value of `key` (or `None` if `key` is missing). This is OK because the contents of the noticeboard are immutable.
3. `notice_write(key, value, condition=None)` - This acquires the `notice` cown and then writes `value` to `key` if condition is satisfied (or none). `condition` is `Callable[[Any, Any], bool]` and is called with the old value and the new value. If there are any callbacks waiting on `key`, they get called here with the new value.
4. `notice_changed(key, callback)` - This code puts `callback` in a region and then acquires the `notice` cown. There is a dictionary in the `notice` region mapping `key` to `callback` regions, and the region gets added there. The next time key changes, the `callback` is called. `callback` is `Callable[[Any], None]`.